### PR TITLE
Fix wrong number of arguments in orgn--camelise-en-GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ After the name is set, you will be asked where to save the story folder.
 
 You will now have a new buffer, `main.org`. This file is the entry point for your story and contains links to the other sections and files that you will use. You can write a brief summary of your story here if you like, but it is purely for your own reference. The only parts of this file that must be left unchanged are the first line which lets Emacs know this is an Org Novelist file, and the first header line which let's Org Novelist know what the story is called.
 
-If you wish to rename your story, is it better to use the command: `org-novelist-rename-story`
+If you wish to rename your story, it is better to use the command: `org-novelist-rename-story`
 
 This will save you having to go through every file that references the story name and manually changing it. It will also give you the option to rename the story folder to match your new title.
 

--- a/org-novelist.el
+++ b/org-novelist.el
@@ -248,9 +248,11 @@ The resultant string should be suitable for all computer systems using en-GB."
 The resultant string should be suitable for all computer systems using en-GB."
   (let* ((white-list (list "A" "a" "B" "b" "C" "c" "D" "d" "E" "e" "F" "f" "G" "g" "H" "h" "I" "i" "J" "j" "K" "k" "L" "l" "M" "m" "N" "n" "O" "o" "P" "p" "Q" "q" "R" "r" "S" "s" "T" "t" "U" "u" "V" "v" "W" "w" "X" "x" "Y" "y" "Z" "z" "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" " "))  ; List of allowed characters in folder names, plus the space character. The space will also be removed later on, but we need it in the white list as it will be used as a word separator.
          (taboo-chars (mapcar 'string (string-to-list (orgn--remove-chars white-list str)))))  ; Add characters to this list that are not in the white list
-    (mapconcat 'identity (mapcar
-                          (lambda (word) (capitalize (downcase word)))
-                          (split-string (orgn--remove-chars taboo-chars str) " ")))))
+    (mapconcat 'identity
+	       (mapcar
+                (lambda (word) (capitalize (downcase word)))
+                (split-string (orgn--remove-chars taboo-chars str) " "))
+	       "")))
 ;;;; British English (en-GB) ends here
 
 


### PR DESCRIPTION
mapconcat requires 3 arguments, function sequence separator. The
separator was missing. Added an empty string.

The should fix for < 29.x version of Emacs